### PR TITLE
shibaken/wildlifelicensing_django5_working to dbca-wa/wildlifelicensing_django5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,13 +39,13 @@ openpyxl==3.1.5
 phonenumbers==8.12.15
 psycopg2-binary==2.9.10
 pycountry==17.1.8
-pypdf==6.2.0
+pypdf==6.9.2
 python-dateutil==2.9.0.post0
 python-decouple==3.8
 reportlab==4.3.1
-setuptools==80.3
+setuptools==82.0.1
 tableschema==1.21.0
 unicodecsv==0.14.1
-urllib3==2.5.0
+urllib3==2.6.3
 whitenoise==6.5.0
 xlsxwriter==1.1.2


### PR DESCRIPTION
- setuptools: 80.3 → 82.0.1 (fixes jaraco.context vulnerabilities)
- urllib3: 2.5.0 → 2.6.3 (fixes 3 HIGH severity vulnerabilities)
- pypdf: 6.2.0 → 6.9.2 (fixes 9 MEDIUM severity vulnerabilities)